### PR TITLE
editorial cleanups

### DIFF
--- a/core/standard/OAPI_Tiles.html
+++ b/core/standard/OAPI_Tiles.html
@@ -413,7 +413,7 @@
 <h2 id="_scope"><a class="anchor" href="#_scope"></a>1. Scope</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>This document specifies the behavior of Web APIs that provide access to tiles of one geospatial data resource or more than one geopatial data resource. This standard defines how to discover which resources offered by the API can be retrieved as tiles, what are the tile matrix sets supported by the geospatial data resources, which are the limits of the tiled space and how to request one tile at a time.</p>
+<p>This document specifies the behavior of Web APIs that provide access to tiles of one geospatial data resource or more than one geospatial data resource. This standard defines how to discover which resources offered by the API can be retrieved as tiles, what are the tile matrix sets supported by the geospatial data resources, which are the limits of the tiled space and how to request one tile at a time.</p>
 </div>
 <div class="paragraph">
 <p>A web API can be combine this standard with other standards to extend the scope of the API by adding functionality.</p>
@@ -440,7 +440,7 @@
 </ul>
 </div>
 <div class="paragraph">
-<p>The Core specifies requirements that all Web APIs have to implement is they are claiming to support tiles from one geopatial resource following the OGC API - Tiles Part 1: core standard.</p>
+<p>The Core specifies requirements that all Web APIs have to implement if they are claiming to support tiles from one geospatial resource following the OGC API - Tiles Part 1: core standard.</p>
 </div>
 <div class="paragraph">
 <p>Another requirements class is:</p>
@@ -453,13 +453,13 @@
 </ul>
 </div>
 <div class="paragraph">
-<p>The Root specifies requirements that all Web APIs have to implement is they are claiming to support tiles from more than one geopatial resource following the OGC API - Tiles Part 1: core standard.</p>
+<p>The Root specifies requirements that all Web APIs have to implement if they are claiming to support tiles from more than one geospatial resource following the OGC API - Tiles Part 1: core standard.</p>
 </div>
 <div class="paragraph">
 <p>This document does not mandate a specific encoding or format for representing tiles. There are no requirements classes making considerations on specify representations.</p>
 </div>
 <div class="paragraph">
-<p><em>Core</em> and <em>Root</em> are comformance classes that act as building blocks that should be implemented in combination with other more fundamental conformance classes that provide support for API discovery, conformity and API formal definition (e.g. OpenAPI). Possible altermantives for these fundamental conformance classes are OGC API - Common Part 1: core, OGC API - Features Part 1: core or any other non-OGC classes that provide this functionality.</p>
+<p><em>Core</em> and <em>Root</em> are conformance classes that act as building blocks that should be implemented in combination with other more fundamental conformance classes that provide support for API discovery, conformity and API formal definition (e.g. OpenAPI). Possible altermantives for these fundamental conformance classes are OGC API - Common Part 1: core, OGC API - Features Part 1: core or any other non-OGC classes that provide this functionality.</p>
 </div>
 <div class="paragraph">
 <p>Conformance with this standard shall be checked using all the relevant tests specified in Annex A (normative) of this document. The framework, concepts, and methodology for testing, and the criteria to be achieved to claim conformance are specified in the OGC Compliance Testing Policies and Procedures and the OGC Compliance Testing web site.</p>
@@ -2660,7 +2660,7 @@ The concept of geospatial data resource path substitutes the concept of "layer" 
 <tr>
 <td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A</p></td>
 <td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><div class="content"><div class="paragraph">
-<p>The tileset SHALL be available as a URI that will be composed by three parts: The first part is the URL of the geopatial data resources followed by the word '/tiles/', and finally followed by the id of the tile matrix set supported.</p>
+<p>The tileset SHALL be available as a URI that will be composed by three parts: The first part is the URL of the geospatial data resources followed by the word '/tiles/', and finally followed by the id of the tile matrix set supported.</p>
 </div></div></td>
 </tr>
 </tbody>

--- a/core/standard/clause_14_oas.adoc
+++ b/core/standard/clause_14_oas.adoc
@@ -1,12 +1,12 @@
 == Requirements class "OpenAPI 3.0"
 
-NOTE: THIS SECTION REQUIERES A CAREFUL REVIEW. PLEASE IGNORE IT
+NOTE: THIS SECTION REQUIRES A CAREFUL REVIEW. PLEASE IGNORE IT
 
 [NOTE]
 ========
 The OAS requirements class should be limited to OpenAPI 3.0 requirements that specific to Map Tile resources. These requirements are an extension to the OpenAPI requirements in OAPI Common.
 
-What follows is from OAPI common.  It should be replaced with approapriate Map Tile centered requirements.
+What follows is from OAPI common.  It should be replaced with appropriate Map Tile centered requirements.
 ========
 
 === Basic requirements

--- a/core/standard/clause_1_scope.adoc
+++ b/core/standard/clause_1_scope.adoc
@@ -1,4 +1,4 @@
 == Scope
-This document specifies the behavior of Web APIs that provide access to tiles of one geospatial data resource or more than one geopatial data resource. This standard defines how to discover which resources offered by the API can be retrieved as tiles, what are the tile matrix sets supported by the geospatial data resources, which are the limits of the tiled space and how to request one tile at a time.
+This document specifies the behavior of Web APIs that provide access to tiles of one geospatial data resource or more than one geospatial data resource. This standard defines how to discover which resources offered by the API can be retrieved as tiles, what are the tile matrix sets supported by the geospatial data resources, which are the limits of the tiled space and how to request one tile at a time.
 
 A web API can be combine this standard with other standards to extend the scope of the API by adding functionality.

--- a/core/standard/clause_2_conformance.adoc
+++ b/core/standard/clause_2_conformance.adoc
@@ -7,17 +7,17 @@ The main requirements class is:
 
 * Core.
 
-The Core specifies requirements that all Web APIs have to implement is they are claiming to support tiles from one geopatial resource following the OGC API - Tiles Part 1: core standard.
+The Core specifies requirements that all Web APIs have to implement if they are claiming to support tiles from one geospatial resource following the OGC API - Tiles Part 1: core standard.
 
 Another requirements class is:
 
 * Root
 
-The Root specifies requirements that all Web APIs have to implement is they are claiming to support tiles from more than one geopatial resource following the OGC API - Tiles Part 1: core standard.
+The Root specifies requirements that all Web APIs have to implement if they are claiming to support tiles from more than one geospatial resource following the OGC API - Tiles Part 1: core standard.
 
 This document does not mandate a specific encoding or format for representing tiles. There are no requirements classes making considerations on specify representations.
 
-_Core_ and _Root_ are comformance classes that act as building blocks that should be implemented in combination with other more fundamental conformance classes that provide support for API discovery, conformity and API formal definition (e.g. OpenAPI). Possible altermantives for these fundamental conformance classes are OGC API - Common Part 1: core, OGC API - Features Part 1: core or any other non-OGC classes that provide this functionality.
+_Core_ and _Root_ are conformance classes that act as building blocks that should be implemented in combination with other more fundamental conformance classes that provide support for API discovery, conformity and API formal definition (e.g. OpenAPI). Possible alternatives for these fundamental conformance classes are OGC API - Common Part 1: core, OGC API - Features Part 1: core or any other non-OGC classes that provide this functionality.
 
 Conformance with this standard shall be checked using all the relevant tests specified in Annex A (normative) of this document. The framework, concepts, and methodology for testing, and the criteria to be achieved to claim conformance are specified in the OGC Compliance Testing Policies and Procedures and the OGC Compliance Testing web site.
 

--- a/core/standard/clause_6_overview.adoc
+++ b/core/standard/clause_6_overview.adoc
@@ -3,7 +3,7 @@
 
 === Evolution from OGC Web Services
 
-OGC Web Service (OWS) standards have historically implemented a Remote-Procedure-Call-over-HTTP architectural style using Extensible Markup Language (XML) for payloads. This was the state-of-the-art when some of the initial versions of OGC Web Services were originally designed in the late 1990s and early 2000s. This architectural style has now a competing RESTful API style that is proposed as an alternative to RPC pattern. A RESTful API style is resource-oriented instead of service-oriented. The Web Map Tile Service 1.0 already defines a resource oriented architechtural style but it lack an API defintion. This OGC API - Tiles standard specifies an API that follows this Web architecture and in particular the W3C/OGC best practices for sharing Spatial Data on the Web as well as the W3C best practices for sharing Data on the Web.
+OGC Web Service (OWS) standards have historically implemented a Remote-Procedure-Call-over-HTTP architectural style using Extensible Markup Language (XML) for payloads. This was the state-of-the-art when some of the initial versions of OGC Web Services were originally designed in the late 1990s and early 2000s. This architectural style has now a competing RESTful API style that is proposed as an alternative to RPC pattern. A RESTful API style is resource-oriented instead of service-oriented. The Web Map Tile Service 1.0 already defines a resource oriented architectural style but it lack an API definition. This OGC API - Tiles standard specifies an API that follows this Web architecture and in particular the W3C/OGC best practices for sharing Spatial Data on the Web as well as the W3C best practices for sharing Data on the Web.
 
 This document provides de necessary elements to incorporate tile support to an API implementation. These elements can be incorporated in an API based on the OGC API - Features Part 1, core or can be incorporated in an API implementation based on the OGC API – Common Part 1, core. Both specifies a kernel of an API approach to services that follows current resource-oriented architecture practices in the OGC. The OGC API - Common standard provides the foundation upon which implementations of the OGC APIs can be built. The OGC API - common can be combined with this standard and other resource-specific OGC API standards to build and OGC API implementation. However, this standard is done in a way that can extend OGC API - Common but does not make  OGC API - Common mandatory. This way This standard it can be reused as a building block in other frameworks.
 
@@ -78,8 +78,8 @@ For the second approach, we provide some examples of paths templates that an Ope
 |Map tile (geospatial resources^1^) |`/map/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}`
 !===
 ^1^: The expression "geospatial resources" means "from more than one geospatial resource or collection"
-^2^: Specified in an annnex of this document, providing support for the "TileJSON" format.
-^3^: Specified in the OGC API - Maps Part1, core
-^4^: Specified in the OGC API - Commonn Part1, core
+^2^: Specified in an annex of this document, providing support for the "TileJSON" format.
+^3^: Specified in the OGC API - Maps Part 1, core
+^4^: Specified in the OGC API - Common Part 1, core
 
-NOTE: Depite the fact that the previous list of path and path templates are used in many implementations of the OGC API - Tiles, the use of these exact paths are not require by this document and others are possible if correctly described in both approaches.
+NOTE: Despite the fact that the previous list of path and path templates are used in many implementations of the OGC API - Tiles, the use of these exact paths are not require by this document and others are possible if correctly described in both approaches.

--- a/core/standard/clause_7_tile_tileSet.adoc
+++ b/core/standard/clause_7_tile_tileSet.adoc
@@ -131,8 +131,6 @@ The following table explains the meaning of the URI template variables.
 |TileCol |column index of tile matrix	|A non-negative integer between 0 and the MatrixWidth – 1. If there is a TileMatrixSetLimits the value is limited between MinTileCol and MaxTileCol
 !===
 
-NOTE: The use of "templated" is inspired by the JSON Hypertext Application Language (HAL), https://tools.ietf.org/html/draft-kelly-json-hal-08
-
 NOTE: TileJSON is an alternative for a tileset description document. See Annex TBD for more details about this format. Currently this specification only supports WebMercatorQuad TileMatrixSet and the reference to it is implicit. The version 3 of this specification provides a mechanism to cite data sources too.
 
 === A tile
@@ -142,7 +140,7 @@ A tile resource is a geospatial resource of a fragment of a more bigger geospati
 As described before a tile path is obtained by extracting a tile URL templated from one of the links with `rel`: `item` in tileset description document and substituting the templated variables of with valid values.
 
 ==== Operation
-This operation allows retrieving a single tile that represents information coming from geospatial data resources.
+This operation allows retrieving a single tile that represents information sourced from geospatial data resources.
 
 include::requirements/tileset/REQ_tc-op.adoc[]
 

--- a/core/standard/clause_8_tile_tileSetsList.adoc
+++ b/core/standard/clause_8_tile_tileSetsList.adoc
@@ -46,7 +46,7 @@ If the server declares also conformity to OGC API - Common or to http://www.open
 {
   "conformsTo": [
     "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/collections",
+    "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset"
   ]
 }

--- a/core/standard/requirements/geodata-tilesets/REQ_desc-links.adoc
+++ b/core/standard/requirements/geodata-tilesets/REQ_desc-links.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/geodata-tilesets/desc-links*
 ^|A |If the API has a mechanism for their geospatial data resources to expose links to geospatial aspects (e.g. feature items, metadata...), the API SHALL include a `link` with the `href` pointing to every tileset supported by the geospatial data resource that presents a tile aspect of this geospatial data resource and with `rel: "tiles"`.
-^|A |The tileset SHALL be available as a URI that will be composed by three parts: The first part is the URL of the geopatial data resources followed by the word '/tiles/', and finally followed by the id of the tile matrix set supported.
+^|A |The tileset SHALL be available as a URI that will be composed by three parts: The first part is the URL of the geospatial data resources followed by the word '/tiles/', and finally followed by the id of the tile matrix set supported.
 |===

--- a/core/standard/requirements/tileset/REQ_tile-template.adoc
+++ b/core/standard/requirements/tileset/REQ_tile-template.adoc
@@ -6,5 +6,5 @@
 ^|B |These links SHALL provide a URL template with the fragment `/tiles` followed by the value of the tileMatrixSet identifier and a URI template that makes use of the following URL template variables {tileMatrix}, {tileRow}, {tileCol}. Once the variables are substituted by their respective valid values, a URL to a tile is obtained.
 ^|C |There SHALL be a link to a tile URI template for each file format that the server supports (the format is indicated in the 'type' attribute of the link)
 ^|D |A property `templated` SHALL be part of the link properties to indicate that the link needs to be processed to substitute the templated variables with valid values before being used as a URL to a tile.
-^|E |The results of this operation SHALL return a single tile that represents information coming from geospatial data resources.
+^|E |The results of this operation SHALL return a single tile that represents information sourced from geospatial data resources.
 |===

--- a/extensions/info/standard/OAPI_Tiles.html
+++ b/extensions/info/standard/OAPI_Tiles.html
@@ -679,8 +679,8 @@ The use of <code>pixel in the screen</code> can create the wrong impression that
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="JSON">{
   "conformsTo": [
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core",
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/collections",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/core"
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/info"
   ]

--- a/extensions/info/standard/clause_2_conformance.adoc
+++ b/extensions/info/standard/clause_2_conformance.adoc
@@ -11,7 +11,7 @@ The _Core_ specifies requirements that all Map Tile APIs have to implement.
 
 *TBD* requirements classes depend on the _Core_ and <enter their purpose here>:
 
-C**apture additional requirements classes here**
+**Capture additional requirements classes here**
 
 Conformance with this standard shall be checked using all the relevant tests specified in Annex A (normative) of this document. The framework, concepts, and methodology for testing, and the criteria to be achieved to claim conformance are specified in the OGC Compliance Testing Policies and Procedures and the OGC Compliance Testing web site.
 

--- a/extensions/multitile/standard/OAPI_Tiles.html
+++ b/extensions/multitile/standard/OAPI_Tiles.html
@@ -704,8 +704,8 @@ Currently, this requirement class does not provide any way that clients or serve
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="JSON">{
   "conformsTo": [
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core",
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/collections",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/core"
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/multitiles"
   ]
@@ -1430,8 +1430,8 @@ Currently, this requirement class does not provide any way that clients or serve
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="JSON">{
   "conformsTo": [
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core",
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/collections",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/core"
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/collections"
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/cols-multitiles"

--- a/extensions/tmxs/standard/OAPI_Tiles.html
+++ b/extensions/tmxs/standard/OAPI_Tiles.html
@@ -765,8 +765,8 @@
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="JSON">{
   "conformsTo": [
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core",
-    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/collections",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/core"
     "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/tmxs"
     "http://www.opengis.net/spec/tilematrixset/1.0/req/tilematrixset2d"

--- a/openapi/swaggerHubUnresolved/ogc-api-common.yaml
+++ b/openapi/swaggerHubUnresolved/ogc-api-common.yaml
@@ -337,7 +337,7 @@ components:
             type: string
             format: uri
           example:
-            - 'http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core'
+            - 'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core'
     exception:
       type: object
       required:
@@ -349,11 +349,11 @@ components:
           type: string
       example:
         code: '500'
-        description: 'An internal server error occured. Incident ID: 1234567. Please contact admin@example.org.'
+        description: 'An internal server error occurred. Incident ID: 1234567. Please contact admin@example.org.'
     extent:
       description: |-
         The extent of the collection. In the Core only spatial and temporal extents are specified. Extensions may add additional members to represent other  extents, for example, thermal or pressure ranges.
-        It is recommended that the statial extent is expected in CRS84 except if this is not possible.
+        It is recommended that the spatial extent is provided in CRS84 where possible.
       type: object
       properties:
         spatial:
@@ -484,15 +484,15 @@ components:
           type: text/html
           title: the API definition in HTML
         - href: 'http://data.example.org/conformance?f=json'
-          rel: conformance
+          rel: http://www.opengis.net/def/rel/ogc/1.0/conformance
           type: application/json
           title: the list of conformance classes implemented by this API
         - href: 'http://data.example.org/collections?f=json'
-          rel: data
+          rel: http://www.opengis.net/def/rel/ogc/1.0/data
           type: application/json
           title: The collections in the dataset in JSON
         - href: 'http://data.example.org/collections?f=html'
-          rel: data
+          rel: http://www.opengis.net/def/rel/ogc/1.0/data
           type: text/html
           title: The collections in the dataset in HTML
     id-link:
@@ -782,16 +782,16 @@ components:
       title: the API definition in HTML
     link-landingPage-conformance:
       href: 'http://data.example.org/conformance?f=json'
-      rel: conformance
+      rel: http://www.opengis.net/def/rel/ogc/1.0/conformance
       type: application/json
       title: the list of conformance classes implemented by this API
     link-landingPage-collections-json:
       href: 'http://data.example.org/collections?f=json'
-      rel: data
+      rel: http://www.opengis.net/def/rel/ogc/1.0/data
       type: application/json
       title: The collections in the dataset in JSON
     link-landingPage-collections-html:
       href: 'http://data.example.org/collections?f=html'
-      rel: data
+      rel: http://www.opengis.net/def/rel/ogc/1.0/data
       type: text/html
       title: The collections in the dataset in HTML

--- a/openapi/swaggerHubUnresolved/ogc-api-features.yaml
+++ b/openapi/swaggerHubUnresolved/ogc-api-features.yaml
@@ -444,6 +444,6 @@ components:
   examples:
     link-collection-items:
       href: 'http://data.example.com/collections/buildings/items'
-      rel: items
+      rel: http://www.opengis.net/def/rel/ogc/1.0/items
       title: Retrieve the items of the buildings collection
       type: 'application/geo+json'

--- a/openapi/swaggerHubUnresolved/ogc-api-map-tiles-opf-xmp-mt-more-1-collection.yaml
+++ b/openapi/swaggerHubUnresolved/ogc-api-map-tiles-opf-xmp-mt-more-1-collection.yaml
@@ -96,9 +96,9 @@ paths:
               example:
                 conformsTo:
                 # OGC API Common core consists on the landingPage, conformance
-                  - 'http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core'
+                  - 'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core'
                   # OGC API Common collections consists adds the capability to have collections
-                  - 'http://www.opengis.net/spec/ogcapi-common-1/1.0/req/collections'
+                  - 'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections'
                   # We need to be sure which ones are still valid when adopting OpenAPI.
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/req/core'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30'

--- a/openapi/swaggerHubUnresolved/ogc-api-tiles-opf-xmp-vt-more-1-collection.yaml
+++ b/openapi/swaggerHubUnresolved/ogc-api-tiles-opf-xmp-vt-more-1-collection.yaml
@@ -92,7 +92,7 @@ paths:
       responses:
         '200':
           description: |-
-            the URIs of all requirements classes supported by this API
+            the URIs of all conformance classes supported by this API
           content:
             application/json:
               schema:
@@ -100,9 +100,9 @@ paths:
               example:
                 conformsTo:              
                   # OGC API Common core consists on the landingPage, conformance
-                  - 'http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core'
+                  - 'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core'
                   # OGC API Common collections consists adds the capability to have collections
-                  - 'http://www.opengis.net/spec/ogcapi-common-1/1.0/req/collections'
+                  - 'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections'
                   # We need to be sure which ones are still valid when adopting OpenAPI.
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.1/req/oas30'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.1/req/html'

--- a/openapi/swaggerhub/map-tiles.yaml
+++ b/openapi/swaggerhub/map-tiles.yaml
@@ -1330,15 +1330,15 @@ components:
             type: text/html
             title: the API definition in HTML
           - href: http://data.example.org/conformance?f=json
-            rel: conformance
+            rel: http://www.opengis.net/def/rel/ogc/1.0/conformance
             type: application/json
             title: the list of conformance classes implemented by this API
           - href: http://data.example.org/collections?f=json
-            rel: data
+            rel: http://www.opengis.net/def/rel/ogc/1.0/data
             type: application/json
             title: The collections in the dataset in JSON
           - href: http://data.example.org/collections?f=html
-            rel: data
+            rel: http://www.opengis.net/def/rel/ogc/1.0/data
             type: text/html
             title: The collections in the dataset in HTML
           - href: http://data.example.org/tileMatrixSets?f=json
@@ -1383,7 +1383,7 @@ components:
             type: application/rdf+xml
             title: CC0-1.0
           - href: http://data.example.com/collections/buildings/items
-            rel: items
+            rel: http://www.opengis.net/def/rel/ogc/1.0/items
             title: Retrieve the items of the buildings collection
             type: application/geo+json
           - href: http://data.example.com/collections/buildings/map/tiles
@@ -1459,7 +1459,7 @@ components:
           type: string
       example:
         code: "500"
-        description: 'An internal server error occured. Incident ID: 1234567. Please
+        description: 'An internal server error occurred. Incident ID: 1234567. Please
           contact admin@example.org.'
     confClasses:
       required:
@@ -1469,7 +1469,7 @@ components:
         conformsTo:
           type: array
           example:
-          - http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core
+          - http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core
           items:
             type: string
             format: uri
@@ -1596,7 +1596,7 @@ components:
           $ref: https://api.swaggerhub.com/domains/UAB-CREAF/ogc-api-common/1.0.0#/components/schemas/temporalExtent
       description: |-
         The extent of the collection. In the Core only spatial and temporal extents are specified. Extensions may add additional members to represent other  extents, for example, thermal or pressure ranges.
-        It is recommended that the statial extent is expected in CRS84 except if this is not possible.
+        It is recommended that the spatial extent is provided in CRS84 where possible.
     spatialExtent:
       required:
       - bbox
@@ -2110,15 +2110,15 @@ components:
         type: text/html
         title: the API definition in HTML
       - href: http://data.example.org/conformance?f=json
-        rel: conformance
+        rel: http://www.opengis.net/def/rel/ogc/1.0/conformance
         type: application/json
         title: the list of conformance classes implemented by this API
       - href: http://data.example.org/collections?f=json
-        rel: data
+        rel: http://www.opengis.net/def/rel/ogc/1.0/data
         type: application/json
         title: The collections in the dataset in JSON
       - href: http://data.example.org/collections?f=html
-        rel: data
+        rel: http://www.opengis.net/def/rel/ogc/1.0/data
         type: text/html
         title: The collections in the dataset in HTML
     tiles:

--- a/openapi/swaggerhub/tiles.yaml
+++ b/openapi/swaggerhub/tiles.yaml
@@ -1056,15 +1056,15 @@ components:
             type: text/html
             title: the API definition in HTML
           - href: http://data.example.org/conformance?f=json
-            rel: conformance
+            rel: http://www.opengis.net/def/rel/ogc/1.0/conformance
             type: application/json
             title: the list of conformance classes implemented by this API
           - href: http://data.example.org/collections?f=json
-            rel: data
+            rel: http://www.opengis.net/def/rel/ogc/1.0/data
             type: application/json
             title: The collections in the dataset in JSON
           - href: http://data.example.org/collections?f=html
-            rel: data
+            rel: http://www.opengis.net/def/rel/ogc/1.0/data
             type: text/html
             title: The collections in the dataset in HTML
           - href: http://data.example.org/tileMatrixSets?f=json
@@ -1109,7 +1109,7 @@ components:
             type: application/rdf+xml
             title: CC0-1.0
           - href: http://data.example.com/collections/buildings/items
-            rel: items
+            rel: http://www.opengis.net/def/rel/ogc/1.0/items
             title: Retrieve the items of the buildings collection
             type: application/geo+json
           - href: http://data.example.com/collections/buildings/tiles
@@ -1178,7 +1178,7 @@ components:
           type: string
       example:
         code: "500"
-        description: 'An internal server error occured. Incident ID: 1234567. Please
+        description: 'An internal server error occurred. Incident ID: 1234567. Please
           contact admin@example.org.'
     confClasses:
       required:
@@ -1188,7 +1188,7 @@ components:
         conformsTo:
           type: array
           example:
-          - http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core
+          - http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core
           items:
             type: string
             format: uri
@@ -1315,7 +1315,7 @@ components:
           $ref: https://api.swaggerhub.com/domains/UAB-CREAF/ogc-api-common/1.0.0#/components/schemas/temporalExtent
       description: |-
         The extent of the collection. In the Core only spatial and temporal extents are specified. Extensions may add additional members to represent other  extents, for example, thermal or pressure ranges.
-        It is recommended that the statial extent is expected in CRS84 except if this is not possible.
+        It is recommended that the spatial extent is provided in CRS84 where possible.
     spatialExtent:
       required:
       - bbox
@@ -1829,15 +1829,15 @@ components:
         type: text/html
         title: the API definition in HTML
       - href: http://data.example.org/conformance?f=json
-        rel: conformance
+        rel: http://www.opengis.net/def/rel/ogc/1.0/conformance
         type: application/json
         title: the list of conformance classes implemented by this API
       - href: http://data.example.org/collections?f=json
-        rel: data
+        rel: http://www.opengis.net/def/rel/ogc/1.0/data
         type: application/json
         title: The collections in the dataset in JSON
       - href: http://data.example.org/collections?f=html
-        rel: data
+        rel: http://www.opengis.net/def/rel/ogc/1.0/data
         type: text/html
         title: The collections in the dataset in HTML
     tile-set_2:


### PR DESCRIPTION
Mostly spelling fixes.

A few `rel` links were updated to match http://docs.opengeospatial.org/DRAFTS/19-072.html#link-relation-conventions