### PR TITLE
Fixed TileMatrix TileRow and TileCol properties data type.

### DIFF
--- a/openapi/schemas/tms/tileMatrixLimits.yaml
+++ b/openapi/schemas/tms/tileMatrixLimits.yaml
@@ -12,18 +12,14 @@ properties:
   tileMatrix:
     type: string
   minTileRow:
-    type: number
-    format: integer
+    type: integer
     minimum: 0
   maxTileRow:
-    type: number
-    format: integer
+    type: integer
     minimum: 0
   minTileCol:
-    type: number
-    format: integer
+    type: integer
     minimum: 0
   maxTileCol:
-    type: number
-    format: integer
+    type: integer
     minimum: 0


### PR DESCRIPTION
Based on the specification it's not possible to have the type number and format integer. 
Modified the min/maxTileRow and min/maxTileCol data-types to integers.