### PR TITLE
Clause 6, 8: Moved clarification (#115)

### DIFF
--- a/core/standard/clause_6_overview.adoc
+++ b/core/standard/clause_6_overview.adoc
@@ -5,6 +5,9 @@
 
 The _OGC API - Tiles_ standard defines building blocks which can be used in a Web API to retrieve geospatial data as tiles that follow the structure defined in _2D Tile Matrix Set and Tileset Metadata_ standard (see <<rc_tiles_core>>).
 
+Services and clients are encouraged to support as many of the TileMatrixSets defined in the OGC TileMatrixSet registry as possible to maximize
+interoperability, but support is not required for any specific tile matrix set.
+
 This document does not specify any requirement for the type of _geospatial data resource_ that could be delivered as tiles.
 Provided that the geospatial data resources can be organized into tiles, they can be supported regardless of whether they are maps, features data,
 coverages, a resource that does not represent data per se (e.g., an annotation) and so forth.

--- a/core/standard/clause_8_tile_tileSet.adoc
+++ b/core/standard/clause_8_tile_tileSet.adoc
@@ -35,9 +35,6 @@ It may optionally also provide additional information, such as:
 A link to a definition of a TileMatrixSet is always required whether a custom TileMatrixSet or a registered TileMatrixSet is used.
 It is recommended that the Web API hosts a local definition of each supported TileMatrixSet to ensure availability.
 
-Services and clients are encouraged to support as many of the TileMatrixSets defined in the OGC TileMatrixSet registry as possible to maximize
-interoperability, but support is not required for any specific tile matrix set.
-
 === Tileset resource
 A tileset consists of a set of tiles obtained by partitioning geospatial data according to a particular TileMatrixSet.
 The tileset metadata contains all the information necessary for a client application to request tiles from the tileset.


### PR DESCRIPTION
- Moved clarification about no specific TileMatrixSet required from Tile Set Conformance class to introduction
- It is not specific to the TileSet conformance class, and was happening late in the document
- As discussed in the May 2022 Space Partition Code Sprint