### PR TITLE
Remove outdated note and unused include

### DIFF
--- a/core/standard/clause_8_tile_tileSet.adoc
+++ b/core/standard/clause_8_tile_tileSet.adoc
@@ -76,10 +76,6 @@ Clients or servers are not required to support a specific default TileMatrixSet.
 
 NOTE: The OGC TileMatrixSets registry is based on the OGC Two Dimensional Tile Matrix Set standard. Refer to Annex D and E for commonly used TileMatrixSets
 
-//include::requirements/tileset/REQ_tile-template.adoc[]
-
-NOTE: The geospatial data resource URL is expected to be the first part of the URL template (presented by the '...' in the previous note) but this standard does not mandate this.
-
 [[TilesetTilesURIResponseExample]]
 .Example fragment of a tileset response for a common TileMatrixSet defined in the OGC NA registry
 =================


### PR DESCRIPTION
Reading the latest published version of [the draft](https://portal.ogc.org/files/?artifact_id=101406&version=1), under Recommendation 7 on page 40, there are two notes that look like this:

<img width="696" alt="image" src="https://user-images.githubusercontent.com/41094/182485012-26bd6e5b-89ac-4ded-bf48-eb5d8bce8b77.png">

The second note is confusing in that it refers to a `...` that doesn't appear in a previous note.

It looks like f4c26fcc4c469fdf079464e5a581c03cdb2607a7 removed the note that this was referring to: https://github.com/opengeospatial/ogcapi-tiles/blob/91a36c89746d1c6f29cf18e57f646cadef1e33cf/core/standard/clause_7_tile_core.adoc#L110

Later, 177600a1b739ccf671d0bd31cfb7e19091b66e89 commented out an `include::requirements/tileset/REQ_tile-template.adoc` and the file that it referred to was then removed in 045eebacc7be01db15347e719dc070cbc610b16e.

This branch proposes removing the outdated note and the commented out `include` directive.
