### PR TITLE
Use the conformance class in the recommendation identifiers

### DIFF
--- a/core/standard/clause_12_tile_collectionsSelection.adoc
+++ b/core/standard/clause_12_tile_collectionsSelection.adoc
@@ -28,7 +28,7 @@ When this parameter refers to more than one geospatial data resource, this param
 comma (",") as the separator between the resource identifiers in the list. Additional white space will not be used to delimit list items. If a geospatial data resource identifier includes a space or comma, it shall be escaped using the URL encoding rules (IETF RFC 2396).
 
 [[per_collections-selection_valid-collections]]
-include::recommendations/collections-selection/PER_collections-selection.adoc[]
+include::recommendations/collections-selection/PER_valid-collections.adoc[]
 
 [[req_collections-selection-response]]
 ==== Response

--- a/core/standard/recommendations/collections-selection/PER_valid-collections.adoc
+++ b/core/standard/recommendations/collections-selection/PER_valid-collections.adoc
@@ -1,4 +1,4 @@
-[[per_tiles-collections-selection]]
+[[per_collections-selection_valid-collections]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Permission {counter:per-id}* |*/per/collections-selection/valid-collections*

--- a/core/standard/recommendations/core/PER_tc-core-html.adoc
+++ b/core/standard/recommendations/core/PER_tc-core-html.adoc
@@ -1,6 +1,6 @@
-[[per_tileset_tc-core-html]]
+[[per_core_tc-core-html]]
 [width="90%",cols="2,6a"]
 |===
-^|*Permission {counter:per-id}* |*/per/tileset/tc-core-html*
+^|*Permission {counter:per-id}* |*/per/core/tc-core-html*
 ^|A |Every `200`-response of an operation of the server MAY support the media type `text/html`.
 |===

--- a/core/standard/recommendations/core/PER_tc-core-tile-encoding.adoc
+++ b/core/standard/recommendations/core/PER_tc-core-tile-encoding.adoc
@@ -1,7 +1,7 @@
-[[per_tileset_tc-core-tile-encoding]]
+[[per_core_tc-core-tile-encoding]]
 [width="90%",cols="2,6a"]
 |===
-^|*Permission {counter:per-id}* |*/per/tileset/tc-core-tile-encoding*
+^|*Permission {counter:per-id}* |*/per/core/tc-core-tile-encoding*
 ^|A |This draft specification does not impose any media type on the encoding of a response containing tiled feature data. For features the media type MAY be GeoJSON, Mapbox vector tiles or other format.
 ^|B |This draft specification does not impose any media type on the encoding of a response containing tiled coverage data. For coverages it MAY be a GeoTIFF, netCDF or other format.
 ^|C |This draft specification does not impose any media type on the encoding of a map tile response. For maps it MAY be a JPEG, PNG or other format.

--- a/core/standard/recommendations/core/REC_tc-deepfullempty.adoc
+++ b/core/standard/recommendations/core/REC_tc-deepfullempty.adoc
@@ -1,7 +1,7 @@
-[[rec_tileset_tc-deepfullempty]]
+[[rec_core_tc-deepfullempty]]
 [width="90%",cols="2,6a"]
 |===
-^|*Recommendation {counter:rec-id}* |*/rec/tileset/tc-deepfullempty*
+^|*Recommendation {counter:rec-id}* |*/rec/core/tc-deepfullempty*
 ^|A | If a requested tile is empty (no data) and all tiles within its extent at all more detailed zoom levels (tile matrices) are guaranteed to also be empty,
  the response header SHOULD include `OATiles-hint: empty`.
 ^|B | If a requested tile is full (e.g., the inside of a polygon for vector features, a solid color for a map, or a grid completely filled with the same value

--- a/core/standard/recommendations/core/REC_tc-success-scale.adoc
+++ b/core/standard/recommendations/core/REC_tc-success-scale.adoc
@@ -1,6 +1,6 @@
-[[rec_tileset_tc-success-scale]]
+[[rec_core_tc-success-scale]]
 [width="90%",cols="2,6a"]
 |===
-^|*Recommendation {counter:rec-id}* |*/rec/tileset/tc-success-scale*
+^|*Recommendation {counter:rec-id}* |*/rec/core/tc-success-scale*
 ^|A |The content of that response SHOULD be simplified to comply with the scale denominator represented by the TileMatrix identified. Full resolution geographical elements are only expected for the lower values of scale denominators.
 |===

--- a/core/standard/recommendations/datetime/PER_datetime-axis.adoc
+++ b/core/standard/recommendations/datetime/PER_datetime-axis.adoc
@@ -1,4 +1,4 @@
-[[per_tiles-datetime-closest]]
+[[per_datetime_closest]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Permission {counter:per-id}* |*/per/datetime/closest*

--- a/core/standard/recommendations/datetime/REC_actual-datetime.adoc
+++ b/core/standard/recommendations/datetime/REC_actual-datetime.adoc
@@ -1,7 +1,7 @@
-[[rec_tiles_actual_datetime]]
+[[rec_datetime_actual-datetime]]
 [width="90%",cols="2,6a"]
 |===
-^|*Recommendation {counter:rec-id}* |*/rec/actual-datetime*
+^|*Recommendation {counter:rec-id}* |*/rec/datetime/actual-datetime*
 ^|A |The server SHOULD add a HTTP header with `OGCAPI-datetime` as a name and a temporal geometry as a value, to indicate the instant or the temporal interval of the content of the resource. The temporal geometries value shall conform to the following syntax (using link:https://tools.ietf.org/html/rfc5234[ABNF]):
 
 [source]

--- a/core/standard/recommendations/tileset/REC_conf_link.adoc
+++ b/core/standard/recommendations/tileset/REC_conf_link.adoc
@@ -1,4 +1,4 @@
-[[rec_tileset-conf-link.adoc]]
+[[rec_tileset-conf-link]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/tileset/conf-link*

--- a/core/standard/recommendations/tileset/REC_header_linktemplates.adoc
+++ b/core/standard/recommendations/tileset/REC_header_linktemplates.adoc
@@ -1,4 +1,4 @@
-[[rec_tileset-header-linktemplates.adoc]]
+[[rec_tileset_header-linktemplates]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/tileset/header-linktemplates*

--- a/core/standard/recommendations/tileset/REC_tileset_bbox.adoc
+++ b/core/standard/recommendations/tileset/REC_tileset_bbox.adoc
@@ -1,4 +1,4 @@
-[[rec_tileset-bbox.adoc]]
+[[rec_tileset_bbox]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/tileset/bbox*

--- a/core/standard/recommendations/tileset/REC_tmxslink.adoc
+++ b/core/standard/recommendations/tileset/REC_tmxslink.adoc
@@ -1,4 +1,4 @@
-[[rec_tileset-tmxslink.adoc]]
+[[rec_tileset_tmxslink]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/tileset/tmxslink*

--- a/core/standard/recommendations/tilesets-list/PER_tilesets-api.adoc
+++ b/core/standard/recommendations/tilesets-list/PER_tilesets-api.adoc
@@ -1,7 +1,7 @@
-[[per_tilesets_api]]
+[[per_tilesets-list_tilesets-api]]
 [width="90%",cols="2,6a"]
 |===
-^|*Permission {counter:per-id}* |*/per/tilesets/tilesets-api*
+^|*Permission {counter:per-id}* |*/per/tilesets-list/tilesets-api*
 ^|A |An API document can advertise a single resource path (expressed as a URI template) to get multiple tilesets.
 ^|B |This URI template will use the `{tileMatrixSetId}` variable. The `{tileMatrixSetId}` variable will be interpreted as one of TileMatrixSet identifiers supported by the resource. In other words, it represents all the TileMatrixSets supported by the resource. Note that a `{tileMatrixSetId}` variable must NOT be used in the templated links of the tileset metadata.
 |===


### PR DESCRIPTION
This updates a number of the permissions and recommendations so that their identifiers include the compliance class (e.g. `/rec/core/*` for a recommendation in the core.

I also adjusted a few of the block identifiers in the docs - trying to be consistent with existing logic.

Fixes #129.