### PR TITLE
Updated links to the OpenLayers examples

### DIFF
--- a/implementations.adoc
+++ b/implementations.adoc
@@ -78,7 +78,7 @@
 | OGC API - Tiles
 | https://github.com/robinhoutmeyers[Robin Houtmeyers]
 
-| https://github.com/openlayers/openlayers/pull/10963[OpenLayers]
+| OpenLayers https://openlayers.org/en/latest/examples/ogc-map-tiles.html[map] and https://openlayers.org/en/latest/examples/ogc-vector-tiles.html[vector] examples
 | OGC API - Tiles
 | https://github.com/tschaub[Tim Schaub]
 


### PR DESCRIPTION
This adds links to the [map](https://openlayers.org/en/latest/examples/ogc-map-tiles.html) and [vector](https://openlayers.org/en/latest/examples/ogc-vector-tiles.html) tiles examples.  I'll update these and graduate them from experimental to stable in the upcoming sprint.

See #137.