### PR TITLE
Updated links to HTML and PDF versions of the standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This GitHub repository contains OGC's multi-part _OGC API - Tiles_ standard for 
 
 This is the **current** working version of this initiative, written using many AsciiDoc files that might be difficult to follow.
 
-Please see the latest compiled draft specification available in [HTML](https://opengeospatial.github.io/ogcna-auto-review/20-057.html) and [PDF](https://opengeospatial.github.io/ogcna-auto-review/20-057.pdf) which are easier to read.
+Please see the latest compiled specification available in [HTML](https://docs.ogc.org/is/20-057/20-057.html) and [PDF](https://docs.ogc.org/is/20-057/20-057.pdf) which are easier to read.
 
 This specification relies on the [_Tile Matrix Set and Tile Set Metadata_ standard](https://github.com/opengeospatial/2D-Tile-Matrix-Set/) (version 2.0: [HTML](https://docs.opengeospatial.org/is/17-083r4/17-083r4.html) or [PDF](https://docs.opengeospatial.org/is/17-083r4/17-083r4.pdf)).
 


### PR DESCRIPTION
Fixed broken links, as discussed on this issue: https://github.com/opengeospatial/ogcapi-tiles/issues/151