### PR TITLE
fix: remove hardcoded enum-ids which should be examples

### DIFF
--- a/openapi/api/all-collections.json
+++ b/openapi/api/all-collections.json
@@ -1,12 +1,26 @@
 {
    "type" : "string",
-   "enum" : [
-      "blueMarble",
-      "NaturalEarth:raster:HYP_HR_SR_OB_DR",
-      "NaturalEarth:cultural:ne_10m_admin_0_countries",
-      "NaturalEarth:physical:bathymetry",
-      "SRTM_ViewFinderPanorama",
-      "HRDEM-Ottawa",
-      "HRDEM-RedRiver"
-   ]
+   "examples" : {
+      "blueMarble" : {
+         "value" : "blueMarble"
+      },
+      "NaturalEarth:raster:HYP_HR_SR_OB_DR" : {
+         "value" : "NaturalEarth:raster:HYP_HR_SR_OB_DR"
+      },
+      "NaturalEarth:cultural:ne_10m_admin_0_countries" : {
+         "value" : "NaturalEarth:cultural:ne_10m_admin_0_countries"
+      },
+      "NaturalEarth:physical:bathymetry" : {
+         "value" : "NaturalEarth:physical:bathymetry"
+      },
+      "SRTM_ViewFinderPanorama" : {
+         "value" : "SRTM_ViewFinderPanorama"
+      },
+      "HRDEM-Ottawa" : {
+         "value" : "HRDEM-Ottawa"
+      },
+      "HRDEM-RedRiver" : {
+         "value" : "HRDEM-RedRiver"
+      }
+   }
 }

--- a/openapi/api/coverage-collections.json
+++ b/openapi/api/coverage-collections.json
@@ -1,8 +1,14 @@
 {
    "type" : "string",
-   "enum" : [
-      "SRTM_ViewFinderPanorama",
-      "HRDEM-Ottawa",
-      "HRDEM-RedRiver"
-   ]
+   "examples" : {
+      "SRTM_ViewFinderPanorama" : {
+         "value" : "SRTM_ViewFinderPanorama"
+      },
+      "HRDEM-Ottawa" : {
+         "value" : "HRDEM-Ottawa"
+      },
+      "HRDEM-RedRiver" : {
+         "value" : "HRDEM-RedRiver"
+      }
+   }
 }

--- a/openapi/api/styles.json
+++ b/openapi/api/styles.json
@@ -1,6 +1,8 @@
 {
    "type" : "string",
-   "enum" : [
-      "default"
-   ]
+   "examples" : {
+      "default" : {
+         "value" : "default"
+      }
+   }
 }

--- a/openapi/api/vectorTiles-collections.json
+++ b/openapi/api/vectorTiles-collections.json
@@ -1,7 +1,11 @@
 {
    "type" : "string",
-   "enum" : [
-      "NaturalEarth:cultural:ne_10m_admin_0_countries",
-      "NaturalEarth:physical:bathymetry"
-   ]
+   "examples" : {
+      "NaturalEarth:cultural:ne_10m_admin_0_countries" : {
+         "value" : "NaturalEarth:cultural:ne_10m_admin_0_countries"
+      },
+      "NaturalEarth:physical:bathymetry" : {
+         "value" : "NaturalEarth:physical:bathymetry"
+      }
+   }
 }


### PR DESCRIPTION
Currently, in a few places the IDs of resources are quite restrictive while in others they are not.

<img width="1845" height="750" alt="image" src="https://github.com/user-attachments/assets/10130681-d21c-4ce4-b8e6-5fc0c80230f3" />

I think, the restrictiveness is a bug in the openapi sepc, as nowhere in the big spec the restrictions that are currently in place come up, or at least I did not find them.

> [!NOTE]
> this also affects https://github.com/opengeospatial/ogcapi-tiles/blob/master/openapi/api/tileMatrixSets.json , but there it might actually not be a bug, since I don't know why one would want anything other than `WebMercatorQuad`